### PR TITLE
Upgrade github.com/gaissmai/bart to v0.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/hslatman/ipstore
 
-go 1.22.0
+go 1.25.7
 
-require github.com/gaissmai/bart v0.13.0
+require github.com/gaissmai/bart v0.26.1
 
-require github.com/bits-and-blooms/bitset v1.14.3 // indirect
+require github.com/bits-and-blooms/bitset v1.24.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,3 @@ module github.com/hslatman/ipstore
 go 1.25.7
 
 require github.com/gaissmai/bart v0.26.1
-
-require github.com/bits-and-blooms/bitset v1.24.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,2 @@
-github.com/bits-and-blooms/bitset v1.14.3 h1:Gd2c8lSNf9pKXom5JtD7AaKO8o7fGQ2LtFj1436qilA=
-github.com/bits-and-blooms/bitset v1.14.3/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
-github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/gaissmai/bart v0.13.0 h1:pItEhXDVVebUa+i978FfQ7ye8xZc1FrMgs8nJPPWAgA=
-github.com/gaissmai/bart v0.13.0/go.mod h1:qSes2fnJ8hB410BW0ymHUN/eQkuGpTYyJcN8sKMYpJU=
 github.com/gaissmai/bart v0.26.1 h1:+w4rnLGNlA2GDVn382Tfe3jOsK5vOr5n4KmigJ9lbTo=
 github.com/gaissmai/bart v0.26.1/go.mod h1:GREWQfTLRWz/c5FTOsIw+KkscuFkIV5t8Rp7Nd1Td5c=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
 github.com/bits-and-blooms/bitset v1.14.3 h1:Gd2c8lSNf9pKXom5JtD7AaKO8o7fGQ2LtFj1436qilA=
 github.com/bits-and-blooms/bitset v1.14.3/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
+github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/gaissmai/bart v0.13.0 h1:pItEhXDVVebUa+i978FfQ7ye8xZc1FrMgs8nJPPWAgA=
 github.com/gaissmai/bart v0.13.0/go.mod h1:qSes2fnJ8hB410BW0ymHUN/eQkuGpTYyJcN8sKMYpJU=
+github.com/gaissmai/bart v0.26.1 h1:+w4rnLGNlA2GDVn382Tfe3jOsK5vOr5n4KmigJ9lbTo=
+github.com/gaissmai/bart v0.26.1/go.mod h1:GREWQfTLRWz/c5FTOsIw+KkscuFkIV5t8Rp7Nd1Td5c=

--- a/ipstore.go
+++ b/ipstore.go
@@ -83,12 +83,12 @@ func (s *Store[T]) RemoveCIDR(key netip.Prefix) (T, error) {
 	var oldVal T
 	var ok bool
 
-	s.table.Modify(key, func(v T, found bool)(_ T, del bool) {
-        oldVal = v
-        ok = found
-	    return v, true
+	s.table.Modify(key, func(v T, found bool) (_ T, del bool) {
+		oldVal = v
+		ok = found
+		return zero[T](), true
 	})
-	
+
 	if !ok {
 		return zero[T](), nil
 	}

--- a/ipstore.go
+++ b/ipstore.go
@@ -80,12 +80,20 @@ func (s *Store[T]) RemoveCIDR(key netip.Prefix) (T, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	value, ok := s.table.GetAndDelete(key)
+	var oldVal T
+	var ok bool
+
+	s.table.Modify(key, func(v T, found bool)(_ T, del bool) {
+        oldVal = v
+        ok = found
+	    return v, true
+	})
+	
 	if !ok {
 		return zero[T](), nil
 	}
 
-	return value, nil
+	return oldVal, nil
 }
 
 // RemoveIPOrCIDR removes the entry associated with an IP or CIDR from [Store].

--- a/ipstore_test.go
+++ b/ipstore_test.go
@@ -274,6 +274,16 @@ func TestCIDRWithIPv4(t *testing.T) {
 	if rr3 != v3 {
 		t.Errorf("removed rr3(%#+v) does not equal v3 (%#+v)", rr3, v3)
 	}
+
+	// verify that the CIDR is removed
+	r3, err = n.GetCIDR(cidr3)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(r3) != 0 {
+		t.Errorf("expected length to be 0; got: %d", len(r3))
+	}
 }
 
 func TestCombinedIPv4(t *testing.T) {


### PR DESCRIPTION
Changes in the RemoveCIDR function code, which are intended to replace the long-defunct table.GetAndDelete() method by using the existing table.Modify() method

The previous limitation of the bart version (0.13) caused serious inconveniences in the use of the https://github.com/hslatman/caddy-crowdsec-bouncer module, and for two days made it impossible to use boucer with caddy HEAD, because the latest caddy uses the nebula package, which uses the latest bart package. I will not describe the confusing network of dependencies; those interested know what it is about.

In short, ipstore compatibility with the latest bart has been sorely needed for a long time.

Just a quick note, I am NOT an expert on matters handled by bart and ipstore!  I simply couldn't work with caddy the way I needed to, and for two days I couldn't build my caddy variant with many modules at all (via xcaddy, of course). Based on the descriptions of the current and discontinued functions/methods, especially Modify(), I assembled a replacement for the old code, which may do the same thing as the now defunct GetAndDelete() method. At least I would like it to be that way :-)

In any case, the ipstore test was successful at this point:
```
go test
go: downloading github.com/gaissmai/bart v0.26.1
PASS
ok      github.com/hslatman/ipstore     0.010s
```
All components of my multi-module project (crowdsec, caddy-defender),  dependent on bart, compile ok,  the resulting mult-caddy builds flawlessly (with local forks and multiple use of _replace_, of course) and seems to work properly on several VPSs.

I would appreciate any corrections and comments from experts on the subject.

Thanks for the great modules, best regards,
jurekl